### PR TITLE
Remove `user-info` class to ensure follow button gets displayed in mobile viewport

### DIFF
--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -127,7 +127,7 @@ class Profile extends React.Component {
       <div className="profile-page">
         <div className="container">
           <div className="row p-4 text-center">
-            <div className="user-info col-xs-12 col-md-8 offset-md-2">
+            <div className="col-xs-12 col-md-8 offset-md-2">
               <img
                 src={profile.image}
                 className="user-img"


### PR DESCRIPTION
# Description

The follow button is not visible on mobile viewport due to the `user-info` CSS class. It can now be displayed after it is removed.